### PR TITLE
fix ts compiled require

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -18,7 +18,17 @@ const schema = {
 }
 
 config.load({
-  env: 'js',
+  env: 'jsjs',
+  configDir,
+  schema
+})
+
+if ((config.get() as MyConfig).port !== 7070) {
+  throw "could not get port value"
+}
+
+config.load({
+  env: 'tsts',
   configDir,
   schema
 })
@@ -28,7 +38,7 @@ if ((config.get() as MyConfig).port !== 8080) {
 }
 
 config.load({
-  env: 'ts',
+  env: 'tsjs',
   configDir,
   schema
 })

--- a/src/load.ts
+++ b/src/load.ts
@@ -28,9 +28,11 @@ export function load ({ env, schema, configDir }: LibConfigOptions) {
   const configFile = path.resolve(path.join(configDirectory, environment))
 
   if (fs.existsSync(`${configFile}.js`)) {
-    const config = require(path.resolve(
+    const required = require(path.resolve(
       path.join(configDirectory, environment)
     ))
+
+    const config = required.config || required
 
     if (!isObject(config)) {
       throw new Error(

--- a/test/config/jsjs.js
+++ b/test/config/jsjs.js
@@ -1,4 +1,4 @@
 module.exports = {
-  port: 8080,
+  port: 7070,
   apiEndpoint: 'https://api.com'
 }

--- a/test/config/tsjs.js
+++ b/test/config/tsjs.js
@@ -1,4 +1,4 @@
-export const config = {
+module.exports.config = {
   port: 9090,
   apiEndpoint: 'https://api.com'
 }

--- a/test/config/tsts.ts
+++ b/test/config/tsts.ts
@@ -1,0 +1,4 @@
+export const config = {
+  port: 8080,
+  apiEndpoint: 'https://api.com'
+}


### PR DESCRIPTION
When the ts app is compiled it assumes a default export but it is
actually on the config property of the export.

Falls back to a default export for js apps if config is not a
property.