### PR TITLE
Improve error message when additional properties are present

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -14,7 +14,15 @@ export function validate ({ config, schema }: Validate) {
 
   if (validate.errors) {
     validate.errors.forEach(e => {
-      console.error(`config error: '${e.dataPath}' ${e.message}`)
+      let errorMessage = 'config error: '
+      if (e.dataPath) {
+        errorMessage += `'${e.dataPath}' `
+      }
+      errorMessage += e.message
+      if (e.keyword === 'additionalProperties') {
+        errorMessage += ` (${(e.params as any).additionalProperty})`
+      }
+      console.error(errorMessage);
     })
     throw new Error('Invalid config')
   }


### PR DESCRIPTION
## Before

```
Loading config for env development
config error: '' should NOT have additional properties
```

## After

```
Loading config for env development
config error: should NOT have additional properties (myPropertyName)
```